### PR TITLE
rename metrics from verify_federation_* to verify_metadata_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ To run the prometheus exporter:
 
 The following metrics are exported:
 
-    - `verify_federation_metadata_expiry`: when the SAML metadata signature expires
-    - `verify_federation_certificate_expiry`: when the given certificate expires
-    - `verify_federation_certificate_ocsp_success`: whether the given certificate passes OCSP
+    - `verify_metadata_expiry`: when the SAML metadata signature expires
+    - `verify_metadata_certificate_expiry`: when the given certificate expires
+    - `verify_metadata_certificate_ocsp_success`: whether the given certificate passes OCSP
 
 ## Contributing
 

--- a/bin/prometheus-metadata-exporter
+++ b/bin/prometheus-metadata-exporter
@@ -11,7 +11,7 @@ require 'sinatra/base'
 
 class ValidUntilMetric < Prometheus::Client::Gauge
   def initialize(metadata_url)
-    super(:verify_federation_metadata_expiry, "The validUntil date of the given metadata")
+    super(:verify_metadata_expiry, "The validUntil date of the given metadata")
     @metadata_url = metadata_url
     @metadata_client = Metadata::SAML::Client.new
     @parser = Metadata::SAML::Parser.new
@@ -35,7 +35,7 @@ end
 
 class ExpiryDateMetric < Prometheus::Client::Gauge
   def initialize(metadata_url)
-    super(:verify_federation_certificate_expiry, "The NotAfter date of the given X.509 SAML certificate")
+    super(:verify_metadata_certificate_expiry, "The NotAfter date of the given X.509 SAML certificate")
     @metadata_url = metadata_url
     @metadata_client = Metadata::SAML::Client.new
     @parser = Metadata::SAML::Parser.new
@@ -83,7 +83,7 @@ end
 # ocsp - same as ExpiryDateMetric but 0 (fail) or 1 (pass)
 class OcspCheckMetric < Prometheus::Client::Gauge
   def initialize(metadata_url, ca_files)
-    super(:verify_federation_certificate_ocsp_success, "If a cert chain validation and OCSP check of the given X.509 SAML certificate is good (1) or bad (0)")
+    super(:verify_metadata_certificate_ocsp_success, "If a cert chain validation and OCSP check of the given X.509 SAML certificate is good (1) or bad (0)")
     @metadata_url = metadata_url
     @ca_files = ca_files
     @metadata_client = Metadata::SAML::Client.new

--- a/features/metadata_checks_are_reported_in_a_prometheus_compatible_metrics_endpoint.feature
+++ b/features/metadata_checks_are_reported_in_a_prometheus_compatible_metrics_endpoint.feature
@@ -23,21 +23,21 @@ Feature: metadata checks are reported in a prometheus compatible metrics endpoin
     When I start the prometheus client on port 2020 with metadata on port 53110 with ca test_pki_one.crt
     Then the metrics on port 2020 should contain exactly:
     """
-    # TYPE verify_federation_certificate_expiry gauge
-    # HELP verify_federation_certificate_expiry The NotAfter date of the given X.509 SAML certificate
-    verify_federation_certificate_expiry{entity_id="foo",use="encryption",key_name="foo_key_1",serial="2",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} (\d+).0
-    verify_federation_certificate_expiry{entity_id="foo",use="encryption",key_name="foo_key_2",serial="3",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} (\d+).0
-    verify_federation_certificate_expiry{entity_id="bar",use="encryption",key_name="bar_key_1",serial="4",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} (\d+).0
-    verify_federation_certificate_expiry{entity_id="metadata_signature",use="",key_name="certificate",serial="2",subject="/DC=org/DC=TEST/CN=SIGNED TEST CERTIFICATE"} (\d+).0
-    # TYPE verify_federation_metadata_expiry gauge
-    # HELP verify_federation_metadata_expiry The validUntil date of the given metadata
-    verify_federation_metadata_expiry{metadata="http://localhost:53110"} 1434720100000.0
-    # TYPE verify_federation_certificate_ocsp_success gauge
-    # HELP verify_federation_certificate_ocsp_success If a cert chain validation and OCSP check of the given X.509 SAML certificate is good \(1\) or bad \(0\)
-    verify_federation_certificate_ocsp_success{entity_id="foo",use="encryption",key_name="foo_key_1",serial="2",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 1.0
-    verify_federation_certificate_ocsp_success{entity_id="foo",use="encryption",key_name="foo_key_2",serial="3",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 1.0
-    verify_federation_certificate_ocsp_success{entity_id="bar",use="encryption",key_name="bar_key_1",serial="4",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 1.0
-    verify_federation_certificate_ocsp_success{entity_id="metadata_signature",use="",key_name="certificate",serial="2",subject="/DC=org/DC=TEST/CN=SIGNED TEST CERTIFICATE"} 1.0
+    # TYPE verify_metadata_certificate_expiry gauge
+    # HELP verify_metadata_certificate_expiry The NotAfter date of the given X.509 SAML certificate
+    verify_metadata_certificate_expiry{entity_id="foo",use="encryption",key_name="foo_key_1",serial="2",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} (\d+).0
+    verify_metadata_certificate_expiry{entity_id="foo",use="encryption",key_name="foo_key_2",serial="3",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} (\d+).0
+    verify_metadata_certificate_expiry{entity_id="bar",use="encryption",key_name="bar_key_1",serial="4",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} (\d+).0
+    verify_metadata_certificate_expiry{entity_id="metadata_signature",use="",key_name="certificate",serial="2",subject="/DC=org/DC=TEST/CN=SIGNED TEST CERTIFICATE"} (\d+).0
+    # TYPE verify_metadata_expiry gauge
+    # HELP verify_metadata_expiry The validUntil date of the given metadata
+    verify_metadata_expiry{metadata="http://localhost:53110"} 1434720100000.0
+    # TYPE verify_metadata_certificate_ocsp_success gauge
+    # HELP verify_metadata_certificate_ocsp_success If a cert chain validation and OCSP check of the given X.509 SAML certificate is good \(1\) or bad \(0\)
+    verify_metadata_certificate_ocsp_success{entity_id="foo",use="encryption",key_name="foo_key_1",serial="2",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 1.0
+    verify_metadata_certificate_ocsp_success{entity_id="foo",use="encryption",key_name="foo_key_2",serial="3",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 1.0
+    verify_metadata_certificate_ocsp_success{entity_id="bar",use="encryption",key_name="bar_key_1",serial="4",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 1.0
+    verify_metadata_certificate_ocsp_success{entity_id="metadata_signature",use="",key_name="certificate",serial="2",subject="/DC=org/DC=TEST/CN=SIGNED TEST CERTIFICATE"} 1.0
     """
 
   Scenario: Check metadata that contains a revoked cert
@@ -56,20 +56,20 @@ Feature: metadata checks are reported in a prometheus compatible metrics endpoin
     When I start the prometheus client on port 2021 with metadata on port 53111 with ca test_pki_one.crt
     Then the metrics on port 2021 should contain exactly:
     """
-    # TYPE verify_federation_certificate_expiry gauge
-    # HELP verify_federation_certificate_expiry The NotAfter date of the given X.509 SAML certificate
-    verify_federation_certificate_expiry{entity_id="foo",use="encryption",key_name="foo_key_1",serial="2",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} (\d+).0
-    verify_federation_certificate_expiry{entity_id="foo",use="encryption",key_name="foo_key_2",serial="3",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} (\d+).0
-    verify_federation_certificate_expiry{entity_id="bar",use="encryption",key_name="bar_key_1",serial="4",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} (\d+).0
-    verify_federation_certificate_expiry{entity_id="metadata_signature",use="",key_name="certificate",serial="2",subject="/DC=org/DC=TEST/CN=SIGNED TEST CERTIFICATE"} (\d+).0
-    # TYPE verify_federation_metadata_expiry gauge
-    # HELP verify_federation_metadata_expiry The validUntil date of the given metadata
-    verify_federation_metadata_expiry{metadata="http://localhost:53111"} 1434720100000.0
-    # TYPE verify_federation_certificate_ocsp_success gauge
-    # HELP verify_federation_certificate_ocsp_success If a cert chain validation and OCSP check of the given X.509 SAML certificate is good \(1\) or bad \(0\)
-    verify_federation_certificate_ocsp_success{entity_id="foo",use="encryption",key_name="foo_key_1",serial="2",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 1.0
-    verify_federation_certificate_ocsp_success{entity_id="foo",use="encryption",key_name="foo_key_2",serial="3",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 1.0
-    verify_federation_certificate_ocsp_success{entity_id="bar",use="encryption",key_name="bar_key_1",serial="4",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 0.0
-    verify_federation_certificate_ocsp_success{entity_id="metadata_signature",use="",key_name="certificate",serial="2",subject="/DC=org/DC=TEST/CN=SIGNED TEST CERTIFICATE"} 1.0
+    # TYPE verify_metadata_certificate_expiry gauge
+    # HELP verify_metadata_certificate_expiry The NotAfter date of the given X.509 SAML certificate
+    verify_metadata_certificate_expiry{entity_id="foo",use="encryption",key_name="foo_key_1",serial="2",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} (\d+).0
+    verify_metadata_certificate_expiry{entity_id="foo",use="encryption",key_name="foo_key_2",serial="3",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} (\d+).0
+    verify_metadata_certificate_expiry{entity_id="bar",use="encryption",key_name="bar_key_1",serial="4",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} (\d+).0
+    verify_metadata_certificate_expiry{entity_id="metadata_signature",use="",key_name="certificate",serial="2",subject="/DC=org/DC=TEST/CN=SIGNED TEST CERTIFICATE"} (\d+).0
+    # TYPE verify_metadata_expiry gauge
+    # HELP verify_metadata_expiry The validUntil date of the given metadata
+    verify_metadata_expiry{metadata="http://localhost:53111"} 1434720100000.0
+    # TYPE verify_metadata_certificate_ocsp_success gauge
+    # HELP verify_metadata_certificate_ocsp_success If a cert chain validation and OCSP check of the given X.509 SAML certificate is good \(1\) or bad \(0\)
+    verify_metadata_certificate_ocsp_success{entity_id="foo",use="encryption",key_name="foo_key_1",serial="2",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 1.0
+    verify_metadata_certificate_ocsp_success{entity_id="foo",use="encryption",key_name="foo_key_2",serial="3",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 1.0
+    verify_metadata_certificate_ocsp_success{entity_id="bar",use="encryption",key_name="bar_key_1",serial="4",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 0.0
+    verify_metadata_certificate_ocsp_success{entity_id="metadata_signature",use="",key_name="certificate",serial="2",subject="/DC=org/DC=TEST/CN=SIGNED TEST CERTIFICATE"} 1.0
     """
 


### PR DESCRIPTION
"Federation" is not a good name. It probably originates from the use
of `/federation` in the metadata URL, but since metadata doesn't
contain all the certificates in the federation (it doesn't include RP
certs), this confuses people.

If we say `metadata` instead, it will be clearer what we mean.

After this change, we'll have to update our grafana dashboards but
this is easier to do now than later.