### PR TITLE
EID-1675 Add support for self-signed certs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install it yourself as:
 
 To generate a package for metadata-exporter:
 
-    docker build
+    docker build ./
 
 Then upload the image to the desired repository.
 
@@ -20,7 +20,11 @@ Then upload the image to the desired repository.
 
 To run the prometheus exporter:
 
-    bundle exec bin/prometheus-metadata-exporter -m METADATA_URL --cas DIRECTORY_OF_CA_CERTIFICATE_FILES
+    bundle exec bin/prometheus-metadata-exporter -m METADATA_URL --cas DIRECTORY_OF_CA_CERTIFICATE_FILES [--allow_self-signed]
+    
+The directory of DIRECTORY_OF_CA_CERTS should contain the certificate chains for the metadata signing cert as well as any signing and encryption certs within the SAML.
+
+Self-signed certs do not need a chain, but you should provide the optional `--allow_self_signed` parameter.
 
 The following metrics are exported:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then upload the image to the desired repository.
 
 To run the prometheus exporter:
 
-    bundle exec bin/prometheus-metadata-exporter -m METADATA_URL --cas DIRECTORY_OF_CA_CERTIFICATE_FILES [--allow_self-signed]
+    bundle exec bin/prometheus-metadata-exporter -m METADATA_URL --cas DIRECTORY_OF_CA_CERTIFICATE_FILES [--allow_self_signed]
     
 The directory of DIRECTORY_OF_CA_CERTS should contain the certificate chains for the metadata signing cert as well as any signing and encryption certs within the SAML.
 

--- a/bin/prometheus-metadata-exporter
+++ b/bin/prometheus-metadata-exporter
@@ -83,7 +83,7 @@ end
 
 # ocsp - same as ExpiryDateMetric but 0 (fail) or 1 (pass)
 class OcspCheckMetric < Prometheus::Client::Gauge
-  def initialize(metadata_url, ca_files)
+  def initialize(metadata_url, ca_files, allow_self_signed)
     super(:verify_metadata_certificate_ocsp_success, "If a cert chain validation and OCSP check of the given X.509 SAML certificate is good (1) or bad (0)")
     @metadata_url = metadata_url
     @ca_files = ca_files
@@ -91,6 +91,7 @@ class OcspCheckMetric < Prometheus::Client::Gauge
     @parser = Metadata::SAML::Parser.new
     @certificate_factory = Metadata::Certificate::CertificateFactory.new
     @pem_checker = Metadata::Ocsp::PemChecker.new
+    @allow_self_signed = allow_self_signed
   end
   def values
     # we're being scraped
@@ -101,10 +102,10 @@ class OcspCheckMetric < Prometheus::Client::Gauge
     document = @metadata_client.get(@metadata_url, false)
 
     # these are all the certs served from the metadata
-    check_and_set(gauge, @parser.certificate_identities(document), @ca_files)
+    check_and_set(gauge, @parser.certificate_identities(document), @ca_files, @allow_self_signed)
 
     # this is the cert used to sign the metadata document itself
-    check_and_set(gauge, @parser.signing_certificate(document), @ca_files)
+    check_and_set(gauge, @parser.signing_certificate(document), @ca_files, @allow_self_signed)
 
     # return the metrics to prometheus
     return gauge.values
@@ -112,15 +113,14 @@ class OcspCheckMetric < Prometheus::Client::Gauge
 
   private
 
-  def check_and_set(gauge, certificate_identities, ca_files)
+  def check_and_set(gauge, certificate_identities, ca_files, allow_self_signed)
       return if certificate_identities.nil?
 
       pems = certificate_identities.keys
-      ocsp_results = @pem_checker.check_pems(pems, ca_files)
+      ocsp_results = @pem_checker.check_pems(pems, ca_files, allow_self_signed)
       certificate_identities.map do |pem, identities|
         identities.map do |identity|
           cert = @certificate_factory.from_inline_pem(pem)
-
           ocsp_result = ocsp_results[pem].revoked? ? 0 : 1
 
           unless ocsp_results[pem].unknown?
@@ -141,14 +141,16 @@ class PrometheusMetadataExporter
   option :port, :short => '-p PORT', required: false, default: 9199, description: "Port to listen on (default 9199)"
   option :metadata_url, :short => '-m METADATA_URL', required: true, description: "URL to fetch metadata from"
   option :ca_file_list, :long => '--cas DIR', required: true, description: "Directory containing CA certificate files in PEM format"
+  option :allow_self_signed, :long => '--allow_self_signed', required: false, boolean: true, description: "Set true to skip OCSP checks for self signed certificates."
 
   def gogogo
+    allow_self_signed = config[:allow_self_signed]
     dir = config[:ca_file_list]
     ca_file_list = Dir.children(dir).collect{|name| File.join(dir,name)}
 
     Prometheus::Client::registry.register(ExpiryDateMetric.new(config[:metadata_url]))
     Prometheus::Client::registry.register(ValidUntilMetric.new(config[:metadata_url]))
-    Prometheus::Client::registry.register(OcspCheckMetric.new(config[:metadata_url], ca_file_list))
+    Prometheus::Client::registry.register(OcspCheckMetric.new(config[:metadata_url], ca_file_list, allow_self_signed))
   end
 end
 

--- a/bin/prometheus-metadata-exporter
+++ b/bin/prometheus-metadata-exporter
@@ -105,7 +105,7 @@ class OcspCheckMetric < Prometheus::Client::Gauge
     check_and_set(gauge, @parser.certificate_identities(document), @ca_files, @allow_self_signed)
 
     # this is the cert used to sign the metadata document itself
-    check_and_set(gauge, @parser.signing_certificate(document), @ca_files, @allow_self_signed)
+    check_and_set(gauge, @parser.signing_certificate(document), @ca_files)
 
     # return the metrics to prometheus
     return gauge.values
@@ -113,7 +113,7 @@ class OcspCheckMetric < Prometheus::Client::Gauge
 
   private
 
-  def check_and_set(gauge, certificate_identities, ca_files, allow_self_signed)
+  def check_and_set(gauge, certificate_identities, ca_files, allow_self_signed = false)
       return if certificate_identities.nil?
 
       pems = certificate_identities.keys

--- a/features/ocsp_checks_certificates_in_metadata.feature
+++ b/features/ocsp_checks_certificates_in_metadata.feature
@@ -7,23 +7,26 @@ Feature: OCSP checks certificates in metadata
   Background:
     Given the OCSP port is 54000
 
+  @selfsign
   Scenario: Check healthy metadata
     Given there are the following PKIs:
       | name         | cert_filename    |
       | TEST_PKI_ONE | test_pki_one.crt |
     Given the following certificates are defined in metadata:
-      | entity_id | key_name  | pki          | status |
-      | foo       | foo_key_1 | TEST_PKI_ONE | good   |
-      | foo       | foo_key_2 | TEST_PKI_ONE | good   |
-      | bar       | bar_key_1 | TEST_PKI_ONE | good   |
+      | entity_id | key_name  | pki          | status     |
+      | foo       | foo_key_1 | TEST_PKI_ONE | good       |
+      | foo       | foo_key_2 | TEST_PKI_ONE | good       |
+      | bar       | bar_key_1 | TEST_PKI_ONE | good       |
+      | car       | car_key_3 | TEST_PKI_ONE | selfsigned |
     And there is metadata at http://localhost:53000
     And there is an OCSP responder
-    When I start the metadata checker with the arguments "-m http://localhost:53000 --cas tmp/aruba/ -p 2020"
+    When I start the metadata checker with the arguments "-m http://localhost:53000 --cas tmp/aruba/ -p 2020 --allow_self_signed"
     Then the metrics on port 2020 should contain exactly:
     """
     verify_metadata_certificate_ocsp_success{entity_id="foo",use="encryption",serial="2",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 1.0
     verify_metadata_certificate_ocsp_success{entity_id="foo",use="encryption",serial="3",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 1.0
     verify_metadata_certificate_ocsp_success{entity_id="bar",use="encryption",serial="4",subject="/DC=org/DC=TEST/CN=GENERATED TEST CERTIFICATE"} 1.0
+    verify_metadata_certificate_ocsp_success{entity_id="car",use="encryption",serial="5",subject="/DC=org/DC=TEST/CN=SELF_SIGNED_CERT"} 1.0
     """
 
   Scenario: Check unhealthy metadata

--- a/features/ocsp_checks_certificates_in_metadata.feature
+++ b/features/ocsp_checks_certificates_in_metadata.feature
@@ -7,7 +7,6 @@ Feature: OCSP checks certificates in metadata
   Background:
     Given the OCSP port is 54000
 
-  @selfsign
   Scenario: Check healthy metadata
     Given there are the following PKIs:
       | name         | cert_filename    |

--- a/features/step_definitions/metadata_checker_steps.rb
+++ b/features/step_definitions/metadata_checker_steps.rb
@@ -39,7 +39,6 @@ Given(/^the following certificates are defined in metadata:$/) do |table|
     when "expired"
       cert = pki.generate_cert_with_expiry(Time.now-(60*60*24*15), "EXPIRED CERT")
     when "selfsigned"
-      puts "selfsigned cert requested"
       pair = pki.generate_cert_and_key(Time.now+(60*60*24*365), "SELF_SIGNED_CERT")
       cert = pair[0]
       key = pair[1]

--- a/lib/metadata/ocsp/pem_checker.rb
+++ b/lib/metadata/ocsp/pem_checker.rb
@@ -10,21 +10,25 @@ module Metadata
         @ocsp_checker = ocsp_checker
       end
 
-      def check_pems(pems, ca_files)
+      def check_pems(pems, ca_files, allow_self_signed)
         ca_certs = ca_files.map { |file| OpenSSL::X509::Certificate.new(File.read(file)) }
         issuer_repository = CertificateRepository.new(ca_certs)
         pems.each.with_object({}) do |pem, results|
-          results[pem] = check_pem(pem, issuer_repository)
+          results[pem] = check_pem(pem, issuer_repository, allow_self_signed)
         end
       end
 
-      def check_pem(pem, issuer_repository)
+      def check_pem(pem, issuer_repository, allow_self_signed)
         cert = @certificate_factory.from_inline_pem(pem)
-        chain = issuer_repository.find_chain(cert)
-        store = chain.store
-        issuer = chain.first
-        raise "An issuer was not found in the ca certs for #{cert.subject.to_s}" if issuer.nil?
-        @ocsp_checker.check([cert], issuer, store)[cert]
+        if (allow_self_signed && cert.subject == cert.issuer) then
+          Ocsp::Result.new(nil, nil)
+        else
+          chain = issuer_repository.find_chain(cert)
+          store = chain.store
+          issuer = chain.first
+          raise "An issuer was not found in the ca certs for #{cert.subject.to_s}" if issuer.nil?
+          @ocsp_checker.check([cert], issuer, store)[cert]
+        end
       end
     end
   end

--- a/spec/support/certificate_helper.rb
+++ b/spec/support/certificate_helper.rb
@@ -3,7 +3,7 @@ module CertificateHelper
   def generate_cert_with_expiry(expiry, cn = "GENERATED TEST CERTIFICATE")
     generate_cert_and_key(expiry, cn)[0]
   end
-  
+
   def generate_cert(cn = "GENERATED TEST CERTIFICATE")
     generate_cert_and_key((Time.now+60*60*24*365), cn)[0]
   end

--- a/spec/support/pki.rb
+++ b/spec/support/pki.rb
@@ -38,7 +38,6 @@ class PKI
 
   def sign(cert, key = nil)
     selfsign = !key.nil?
-    puts "selfsign in progress" if selfsign
     cert.issuer = selfsign ? cert.subject : @root_ca.subject
     cert.serial = take_next_serial
     ef = OpenSSL::X509::ExtensionFactory.new


### PR DESCRIPTION
Proxy node metadata can contain self-signed certificates. This PR adds support for self-signed certs in the metadata checker:
* Introduces a new parameter: `--allow_self_signed`
* Detects self-signed certificates (where `subject == issuer`)
* When the new parameter is set, skips the OCSP checks for self-signed certificates _in_ the metadata