### PR TITLE
disable pretty exceptions

### DIFF
--- a/bin/prometheus-metadata-exporter
+++ b/bin/prometheus-metadata-exporter
@@ -160,6 +160,7 @@ class App < Sinatra::Base
 
   set :port, exporter.config[:port]
   set :bind, '0.0.0.0'
+  set :show_exceptions, false
 
   exporter.gogogo
   run!


### PR DESCRIPTION
we have seen attempts to render exceptions as "pretty" html pages end up
masking the error itself, we don't need html rendered errors so just
disable them.