### PR TITLE
[HUB-841] Move to using build args for FROM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ruby:2.5.3
+ARG base_image=ruby:2.5.3
+FROM ${base_image}
 
 EXPOSE 9199
 


### PR DESCRIPTION
As part of 841 we're moving back to DockerHub from GHCR. We've also moved from docker-image and standard builder commands to using the vito/oci-build-task and registry-image.

In order to use a base image of our choice (i.e one we've pulled with credentials and to our spec) I've swapped this Dockerfile to using a build argument for the FROM.

It will also help us should we ever decide to go back to GHCR 😂 or somewhere else in the future.